### PR TITLE
Add interactive '#' meta-command input mode

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -6584,6 +6584,7 @@ var Nethack3DEngine = class {
     this.gameMessages = [];
     this.floatingMessageLayer = null;
     this.floatingMessageEntries = [];
+    this.metaCommandOverlay = null;
     this.hasSeenPlayerPosition = false;
     this.hasPlayerMovedOnce = false;
     this.lastMovementInputAtMs = 0;
@@ -6626,6 +6627,8 @@ var Nethack3DEngine = class {
     };
     this.session = null;
     this.metaInputPrefix = "__META__:";
+    this.isInMetaCommandInput = false;
+    this.metaCommandBuffer = "";
     this.altOrMetaHeld = false;
     // Camera controls
     this.cameraDistance = 20;
@@ -8256,9 +8259,11 @@ var Nethack3DEngine = class {
     );
   }
   relayoutFloatingMessages() {
+    const offsetIndex = this.metaCommandOverlay ? 1 : 0;
     for (let i = 0; i < this.floatingMessageEntries.length; i += 1) {
       const entry = this.floatingMessageEntries[i];
-      entry.container.style.top = `${-i * this.floatingMessageStackSpacingPx}px`;
+      const stackIndex = i + offsetIndex;
+      entry.container.style.top = `${-stackIndex * this.floatingMessageStackSpacingPx}px`;
     }
   }
   removeFloatingMessageEntry(entry, relayout = true) {
@@ -8272,6 +8277,54 @@ var Nethack3DEngine = class {
     if (relayout) {
       this.relayoutFloatingMessages();
     }
+  }
+  beginMetaCommandInput() {
+    if (this.isInQuestion || this.isInDirectionQuestion) {
+      return;
+    }
+    this.isInMetaCommandInput = true;
+    this.metaCommandBuffer = "";
+    this.renderMetaCommandOverlay();
+  }
+  endMetaCommandInput() {
+    this.isInMetaCommandInput = false;
+    this.metaCommandBuffer = "";
+    if (this.metaCommandOverlay) {
+      this.metaCommandOverlay.container.remove();
+      this.metaCommandOverlay = null;
+    }
+    this.relayoutFloatingMessages();
+  }
+  renderMetaCommandOverlay() {
+    if (!this.floatingMessageLayer || !document.body.contains(this.floatingMessageLayer)) {
+      return;
+    }
+    if (!this.metaCommandOverlay) {
+      const messageContainer = document.createElement("div");
+      messageContainer.className = "floating-message-container floating-message-container-persistent";
+      messageContainer.style.top = "0px";
+      const floatingText = document.createElement("div");
+      floatingText.className = "floating-message-text floating-message-text-persistent";
+      messageContainer.appendChild(floatingText);
+      this.floatingMessageLayer.appendChild(messageContainer);
+      this.metaCommandOverlay = {
+        container: messageContainer,
+        text: floatingText
+      };
+    }
+    this.metaCommandOverlay.text.textContent = `#${this.metaCommandBuffer}`;
+    this.relayoutFloatingMessages();
+  }
+  submitMetaCommandInput() {
+    this.sendInput("#");
+    for (const char of this.metaCommandBuffer) {
+      this.sendInput(char);
+    }
+    this.sendInput("Enter");
+    this.endMetaCommandInput();
+  }
+  cancelMetaCommandInput() {
+    this.endMetaCommandInput();
   }
   updateStatus(status) {
     const statusElement = document.getElementById("game-status");
@@ -9079,6 +9132,39 @@ var Nethack3DEngine = class {
   handleKeyDown(event) {
     if (event.key === "Alt" || event.key === "Meta") {
       this.altOrMetaHeld = true;
+      event.preventDefault();
+      return;
+    }
+    if (!this.isInMetaCommandInput && event.key === "#" && !event.ctrlKey && !event.altKey && !event.metaKey) {
+      event.preventDefault();
+      this.beginMetaCommandInput();
+      return;
+    }
+    if (this.isInMetaCommandInput) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        this.cancelMetaCommandInput();
+        return;
+      }
+      if (event.key === "Enter") {
+        event.preventDefault();
+        this.submitMetaCommandInput();
+        return;
+      }
+      if (event.key === "Backspace") {
+        event.preventDefault();
+        if (this.metaCommandBuffer.length > 0) {
+          this.metaCommandBuffer = this.metaCommandBuffer.slice(0, -1);
+          this.renderMetaCommandOverlay();
+        }
+        return;
+      }
+      if (/^[a-zA-Z]$/.test(event.key)) {
+        event.preventDefault();
+        this.metaCommandBuffer += event.key.toLowerCase();
+        this.renderMetaCommandOverlay();
+        return;
+      }
       event.preventDefault();
       return;
     }

--- a/public/styles.css
+++ b/public/styles.css
@@ -253,6 +253,15 @@ canvas {
   will-change: transform, opacity;
 }
 
+.floating-message-container-persistent {
+  transition: none;
+}
+
+.floating-message-text-persistent {
+  transition: none;
+  opacity: 1;
+}
+
 .nh3d-dialog {
   position: fixed;
   top: 50%;

--- a/src/game/Nethack3DEngine.ts
+++ b/src/game/Nethack3DEngine.ts
@@ -37,6 +37,11 @@ type FloatingMessageEntry = {
   removeTimerId: number;
 };
 
+type MetaCommandOverlay = {
+  container: HTMLDivElement;
+  text: HTMLDivElement;
+};
+
 type PendingCharacterDamage = {
   amount: number;
   createdAtMs: number;
@@ -91,6 +96,7 @@ class Nethack3DEngine {
   private gameMessages: string[] = [];
   private floatingMessageLayer: HTMLDivElement | null = null;
   private floatingMessageEntries: FloatingMessageEntry[] = [];
+  private metaCommandOverlay: MetaCommandOverlay | null = null;
   private hasSeenPlayerPosition: boolean = false;
   private hasPlayerMovedOnce: boolean = false;
   private lastMovementInputAtMs: number = 0;
@@ -133,6 +139,8 @@ class Nethack3DEngine {
 
   private session: RuntimeBridge | null = null;
   private readonly metaInputPrefix = "__META__:";
+  private isInMetaCommandInput: boolean = false;
+  private metaCommandBuffer: string = "";
   private altOrMetaHeld: boolean = false;
 
   // Camera controls
@@ -2200,9 +2208,12 @@ class Nethack3DEngine {
   }
 
   private relayoutFloatingMessages(): void {
+    const offsetIndex = this.metaCommandOverlay ? 1 : 0;
+
     for (let i = 0; i < this.floatingMessageEntries.length; i += 1) {
       const entry = this.floatingMessageEntries[i];
-      entry.container.style.top = `${-i * this.floatingMessageStackSpacingPx}px`;
+      const stackIndex = i + offsetIndex;
+      entry.container.style.top = `${-stackIndex * this.floatingMessageStackSpacingPx}px`;
     }
   }
 
@@ -2223,6 +2234,73 @@ class Nethack3DEngine {
     if (relayout) {
       this.relayoutFloatingMessages();
     }
+  }
+
+  private beginMetaCommandInput(): void {
+    if (this.isInQuestion || this.isInDirectionQuestion) {
+      return;
+    }
+    this.isInMetaCommandInput = true;
+    this.metaCommandBuffer = "";
+    this.renderMetaCommandOverlay();
+  }
+
+  private endMetaCommandInput(): void {
+    this.isInMetaCommandInput = false;
+    this.metaCommandBuffer = "";
+
+    if (this.metaCommandOverlay) {
+      this.metaCommandOverlay.container.remove();
+      this.metaCommandOverlay = null;
+    }
+
+    this.relayoutFloatingMessages();
+  }
+
+  private renderMetaCommandOverlay(): void {
+    if (
+      !this.floatingMessageLayer ||
+      !document.body.contains(this.floatingMessageLayer)
+    ) {
+      return;
+    }
+
+    if (!this.metaCommandOverlay) {
+      const messageContainer = document.createElement("div");
+      messageContainer.className =
+        "floating-message-container floating-message-container-persistent";
+      messageContainer.style.top = "0px";
+
+      const floatingText = document.createElement("div");
+      floatingText.className =
+        "floating-message-text floating-message-text-persistent";
+
+      messageContainer.appendChild(floatingText);
+      this.floatingMessageLayer.appendChild(messageContainer);
+
+      this.metaCommandOverlay = {
+        container: messageContainer,
+        text: floatingText,
+      };
+    }
+
+    this.metaCommandOverlay.text.textContent = `#${this.metaCommandBuffer}`;
+    this.relayoutFloatingMessages();
+  }
+
+  private submitMetaCommandInput(): void {
+    this.sendInput("#");
+
+    for (const char of this.metaCommandBuffer) {
+      this.sendInput(char);
+    }
+
+    this.sendInput("Enter");
+    this.endMetaCommandInput();
+  }
+
+  private cancelMetaCommandInput(): void {
+    this.endMetaCommandInput();
   }
 
   private updateStatus(status: string): void {
@@ -3330,6 +3408,51 @@ class Nethack3DEngine {
   private handleKeyDown(event: KeyboardEvent): void {
     if (event.key === "Alt" || event.key === "Meta") {
       this.altOrMetaHeld = true;
+      event.preventDefault();
+      return;
+    }
+
+    if (
+      !this.isInMetaCommandInput &&
+      event.key === "#" &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.metaKey
+    ) {
+      event.preventDefault();
+      this.beginMetaCommandInput();
+      return;
+    }
+
+    if (this.isInMetaCommandInput) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        this.cancelMetaCommandInput();
+        return;
+      }
+
+      if (event.key === "Enter") {
+        event.preventDefault();
+        this.submitMetaCommandInput();
+        return;
+      }
+
+      if (event.key === "Backspace") {
+        event.preventDefault();
+        if (this.metaCommandBuffer.length > 0) {
+          this.metaCommandBuffer = this.metaCommandBuffer.slice(0, -1);
+          this.renderMetaCommandOverlay();
+        }
+        return;
+      }
+
+      if (/^[a-zA-Z]$/.test(event.key)) {
+        event.preventDefault();
+        this.metaCommandBuffer += event.key.toLowerCase();
+        this.renderMetaCommandOverlay();
+        return;
+      }
+
       event.preventDefault();
       return;
     }

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -257,6 +257,16 @@ canvas {
   will-change: transform, opacity;
 }
 
+
+.floating-message-container-persistent {
+  transition: none;
+}
+
+.floating-message-text-persistent {
+  transition: none;
+  opacity: 1;
+}
+
 .nh3d-dialog {
   position: fixed;
   top: 50%;


### PR DESCRIPTION
### Motivation
- Provide support for NetHack meta-commands (entered by pressing `#`) so users can type single-letter meta commands without sending movement input, and have a clear persistent prompt while composing them.

### Description
- Added a meta-command input mode to `Nethack3DEngine` with new fields `isInMetaCommandInput`, `metaCommandBuffer`, and `metaCommandOverlay`, plus helper methods `beginMetaCommandInput`, `renderMetaCommandOverlay`, `submitMetaCommandInput`, and `cancelMetaCommandInput` to manage the lifecycle and UI of the mode (`src/game/Nethack3DEngine.ts`).
- Integrated the mode into the existing key pipeline by intercepting `#` in `handleKeyDown`, suspending normal movement/dialog routing while active, accepting letter inputs and `Backspace`, submitting with `Enter` (sends `#` + letters + `Enter` to the runtime via `sendInput`), and cancelling with `Escape` (restores normal input handling).
- Adjusted floating-message layout so the persistent meta prompt occupies the top slot and other floating messages stack beneath it by changing `relayoutFloatingMessages` to offset entries when the meta overlay is present.
- Added CSS variants for persistent floating prompt (`.floating-message-container-persistent` and `.floating-message-text-persistent`) in `src/styles/app.scss` and rebuilt `public/styles.css` and `public/app.js` so the persistent prompt does not fade/translate like transient messages.

### Testing
- Built assets with `npm run build` and verified the build completed successfully (public JS/CSS updated). (success)
- Launched the app with `npm run dev` to validate runtime behavior and UI (server started on port 3000). (success)
- Performed a browser verification using Playwright: opened the app, pressed `#`, typed `name`, and captured a screenshot showing the persistent `#name` overlay (artifact saved during validation). (manual UI check, success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69889d741a688332924b2ca782d96bbc)