### PR TITLE
FPS: Remap direction keys to mouse-look, support numpad diagonals, billboard raycast, and chamfered tile textures

### DIFF
--- a/src/game/Nethack3DEngine.ts
+++ b/src/game/Nethack3DEngine.ts
@@ -4331,16 +4331,21 @@ class Nethack3DEngine implements Nethack3DEngineController {
 
     const fpsWallChamferMask = Number(mesh.userData?.fpsWallChamferMask ?? 0);
     if (isWall && fpsWallChamferMask > 0) {
-      // Chamfered FPS wall geometry uses groups: cap (0), straight walls (1), cut corners (2).
-      // Tint cut corners with nearby floor-like material to expose a readable diagonal passage.
-      const chamferKind =
-        typeof mesh.userData?.fpsWallChamferMaterialKind === "string"
-          ? (mesh.userData.fpsWallChamferMaterialKind as TileMaterialKind)
-          : null;
-      const chamferMaterial = chamferKind
-        ? this.getMaterialByKind(chamferKind)
-        : baseMaterial;
-      mesh.material = [overlay.material, baseMaterial, chamferMaterial];
+      if (useTiles) {
+        // Keep chamfered wall faces in tiles mode textured like the base wall tile.
+        mesh.material = [overlay.material, overlay.material, overlay.material];
+      } else {
+        // Chamfered FPS wall geometry uses groups: cap (0), straight walls (1), cut corners (2).
+        // Tint cut corners with nearby floor-like material to expose a readable diagonal passage.
+        const chamferKind =
+          typeof mesh.userData?.fpsWallChamferMaterialKind === "string"
+            ? (mesh.userData.fpsWallChamferMaterialKind as TileMaterialKind)
+            : null;
+        const chamferMaterial = chamferKind
+          ? this.getMaterialByKind(chamferKind)
+          : baseMaterial;
+        mesh.material = [overlay.material, baseMaterial, chamferMaterial];
+      }
     } else if (isWall) {
       if (mesh.userData.materialKind === "door" && useTiles) {
         mesh.material = [
@@ -5393,6 +5398,8 @@ class Nethack3DEngine implements Nethack3DEngineController {
     const floorZ = isWall ? WALL_HEIGHT + 0.03 : 0.028;
     const newZ = (verticalOffset - 0.5) * scaleBase + floorZ;
     sprite.position.set(x * TILE_SIZE, -y * TILE_SIZE, newZ);
+    sprite.userData.tileX = x;
+    sprite.userData.tileY = y;
     sprite.userData.elevatedZ = newZ;
 
     const shadowScale = (scaleBase * contentWidth * 1.25) / (TILE_SIZE * 0.8);
@@ -9029,8 +9036,93 @@ class Nethack3DEngine implements Nethack3DEngineController {
     };
   }
 
-  private tryResolveFpsMovementInput(key: string): string | null {
-    const lower = key.toLowerCase();
+  private getFpsRelativeDirectionOffset(
+    event: KeyboardEvent,
+  ): { dx: number; dy: number } | null {
+    const lower = event.key.toLowerCase();
+    switch (lower) {
+      case "k":
+      case "arrowup":
+        return { dx: 0, dy: -1 };
+      case "j":
+      case "arrowdown":
+        return { dx: 0, dy: 1 };
+      case "h":
+      case "arrowleft":
+        return { dx: -1, dy: 0 };
+      case "l":
+      case "arrowright":
+        return { dx: 1, dy: 0 };
+      case "y":
+        return { dx: -1, dy: -1 };
+      case "u":
+        return { dx: 1, dy: -1 };
+      case "b":
+        return { dx: -1, dy: 1 };
+      case "n":
+        return { dx: 1, dy: 1 };
+      default:
+        break;
+    }
+
+    switch (event.key) {
+      case "Home":
+        return { dx: -1, dy: -1 };
+      case "PageUp":
+        return { dx: 1, dy: -1 };
+      case "End":
+        return { dx: -1, dy: 1 };
+      case "PageDown":
+        return { dx: 1, dy: 1 };
+      default:
+        break;
+    }
+
+    switch (event.code) {
+      case "Numpad8":
+        return { dx: 0, dy: -1 };
+      case "Numpad2":
+        return { dx: 0, dy: 1 };
+      case "Numpad4":
+        return { dx: -1, dy: 0 };
+      case "Numpad6":
+        return { dx: 1, dy: 0 };
+      case "Numpad7":
+        return { dx: -1, dy: -1 };
+      case "Numpad9":
+        return { dx: 1, dy: -1 };
+      case "Numpad1":
+        return { dx: -1, dy: 1 };
+      case "Numpad3":
+        return { dx: 1, dy: 1 };
+      default:
+        return null;
+    }
+  }
+
+  private getFpsDirectionInputFromRelativeOffset(
+    relativeDx: number,
+    relativeDy: number,
+  ): string | null {
+    const aim = this.getFpsAimDirectionFromCamera();
+    if (!aim) {
+      return null;
+    }
+    const rightX = -aim.dy;
+    const rightY = aim.dx;
+    const forwardScale = -relativeDy;
+    const worldDx = Math.sign(aim.dx * forwardScale + rightX * relativeDx);
+    const worldDy = Math.sign(aim.dy * forwardScale + rightY * relativeDx);
+    return this.getDirectionInputFromMapDelta(worldDx, worldDy);
+  }
+
+  private tryResolveFpsMovementInput(event: KeyboardEvent): string | null {
+    const offset = this.getFpsRelativeDirectionOffset(event);
+    if (offset) {
+      return this.getFpsDirectionInputFromRelativeOffset(offset.dx, offset.dy);
+    }
+
+    const lower = event.key.toLowerCase();
     const aim = this.getFpsAimDirectionFromCamera();
     if (!aim) {
       return null;
@@ -9466,7 +9558,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
       !event.ctrlKey &&
       !event.metaKey
     ) {
-      const fpsMoveInput = this.tryResolveFpsMovementInput(event.key);
+      const fpsMoveInput = this.tryResolveFpsMovementInput(event);
       if (fpsMoveInput) {
         event.preventDefault();
         if (event.shiftKey) {
@@ -10104,7 +10196,13 @@ class Nethack3DEngine implements Nethack3DEngineController {
     const targetY = this.playerPos.y + aim.dy;
     const targetKey = `${targetX},${targetY}`;
     const targetTile = this.tileMap.get(targetKey);
-    const targetZ = targetTile?.userData?.isWall ? WALL_HEIGHT + 0.02 : 0.03;
+    if (!targetTile) {
+      if (this.fpsForwardHighlight) {
+        this.fpsForwardHighlight.visible = false;
+      }
+      return;
+    }
+    const targetZ = targetTile.userData?.isWall ? WALL_HEIGHT + 0.02 : 0.03;
 
     if (this.fpsForwardHighlight) {
       this.fpsForwardHighlight.position.set(
@@ -10190,7 +10288,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
     key: string;
     x: number;
     y: number;
-    mesh: THREE.Mesh;
+    mesh: THREE.Object3D;
   } | null {
     const tiles = Array.from(this.tileMap.values());
     if (tiles.length === 0) {
@@ -10199,18 +10297,28 @@ class Nethack3DEngine implements Nethack3DEngineController {
 
     this.pointerNdc.set(0, 0);
     this.pointerRaycaster.setFromCamera(this.pointerNdc, this.camera);
-    const intersections = this.pointerRaycaster.intersectObjects(tiles, false);
+    const billboards = Array.from(this.monsterBillboards.values());
+    const intersections = this.pointerRaycaster.intersectObjects(
+      [...tiles, ...billboards],
+      false,
+    );
     if (intersections.length === 0) {
       return null;
     }
 
     const hit = intersections[0]?.object;
-    if (!(hit instanceof THREE.Mesh)) {
+    if (!(hit instanceof THREE.Mesh) && !(hit instanceof THREE.Sprite)) {
       return null;
     }
 
-    const x = Math.round(hit.position.x / TILE_SIZE);
-    const y = Math.round(-hit.position.y / TILE_SIZE);
+    const tileX = Number(hit.userData?.tileX);
+    const tileY = Number(hit.userData?.tileY);
+    const x = Number.isFinite(tileX)
+      ? tileX
+      : Math.round(hit.position.x / TILE_SIZE);
+    const y = Number.isFinite(tileY)
+      ? tileY
+      : Math.round(-hit.position.y / TILE_SIZE);
     if (!Number.isFinite(x) || !Number.isFinite(y)) {
       return null;
     }
@@ -10439,7 +10547,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
 
   private getFpsCrosshairHintFromTile(
     key: string,
-    mesh: THREE.Mesh,
+    mesh: THREE.Object3D,
   ): FpsCrosshairTargetHint {
     if (
       Boolean(mesh.userData?.isMonsterLikeCharacter) ||
@@ -10480,7 +10588,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
 
   private getFpsCrosshairActionsForTile(
     key: string,
-    mesh: THREE.Mesh,
+    mesh: THREE.Object3D,
     glanceHint: FpsCrosshairTargetHint | null = null,
   ): FpsContextAction[] {
     const actions: FpsContextAction[] = [];
@@ -10639,7 +10747,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
 
   private getFpsCrosshairTitle(
     key: string,
-    mesh: THREE.Mesh,
+    mesh: THREE.Object3D,
     glanceHint: FpsCrosshairTargetHint | null = null,
   ): string {
     const hint = glanceHint ?? this.getFpsCrosshairHintFromTile(key, mesh);
@@ -10896,7 +11004,11 @@ class Nethack3DEngine implements Nethack3DEngineController {
     } else {
       key = absY >= absX ? (dy < 0 ? "w" : "s") : dx < 0 ? "a" : "d";
     }
-    return this.tryResolveFpsMovementInput(key);
+    const mockEvent = {
+      key,
+      code: key,
+    } as KeyboardEvent;
+    return this.tryResolveFpsMovementInput(mockEvent);
   }
 
   private resolveDirectionKeyFromDelta(


### PR DESCRIPTION
### Motivation

- Improve FPS-mode controls so conventional direction keys (hjkl/yubn, arrows, nav keys and numpad) map relative to the current mouse-look forward direction, including diagonals.
- Ensure FPS right-click/look raycast can hit monster/item billboards so look/context actions resolve to the correct underlying tile.
- Hide the FPS "next move" highlight when the aimed square is missing (undiscovered/void) to avoid showing invalid move targets.
- Fix chamfered FPS wall block rendering in tiles mode so chamfer groups receive tile textures instead of flat colors.

### Description

- Added FPS-relative direction mapping helpers: `getFpsRelativeDirectionOffset` and `getFpsDirectionInputFromRelativeOffset`, and changed `tryResolveFpsMovementInput` to accept a `KeyboardEvent` and route nav keys through the new logic so direction keys are interpreted relative to mouse-look (supports hjklyubn, arrows, Home/PageUp/End/PageDown, and Numpad diagonals).
- Routed touch-swipe movement resolution through the same FPS resolver by creating a mock `KeyboardEvent` for swipe-derived keys so swipes remain aligned with mouse-look.
- Updated FPS aim highlighting to suppress the forward highlight when the target tile mesh is missing (returns early if the aimed tile is not present) so undiscovered/void tiles are not shown as possible moves.
- Extended the crosshair raycast to include monster/loot billboards (`Sprite`) in intersection checks and made billboard setup populate `userData.tileX`/`tileY`, then resolve billboard hits back to their tile coordinates so look/context actions target the correct tile.
- Adjusted chamfer handling in `applyGlyphMaterial` so chamfered wall geometry uses tile overlay materials when `tilesetMode === 'tiles'`, preserving expected tile texturing on chamfer groups.
- Minor adjustments: store tile coords on sprites and widen some function parameter types to `THREE.Object3D` to allow sprite/mesh handling in crosshair code.

### Testing

- Ran TypeScript check: `npx tsc --noEmit` which failed, but failures are unrelated pre-existing type errors in `src/ui/App.tsx` (not introduced by this change).
- Started the local dev server (`npm run dev`) and captured a UI screenshot to validate rendering/interaction visually; the server launched and a screenshot (`artifacts/fps-updates.png`) was produced.
- No additional automated unit tests exist for these runtime/renderer interactions; changes were validated via the dev server smoke test above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a85ed45bc8332a8ba4bea4aa345a2)