### PR TITLE
Add classic ASCII color mode

### DIFF
--- a/src/game/Nethack3DEngine.ts
+++ b/src/game/Nethack3DEngine.ts
@@ -38,6 +38,7 @@ import {
   isSinkCmapGlyph,
   isVerticalDoorCmapGlyph,
 } from "./glyphs/behavior";
+import { getNetHackColorHex } from "./glyphs/colors";
 import {
   getGlyphCatalogEntry,
   getGlyphCatalogRanges,
@@ -7070,6 +7071,8 @@ class Nethack3DEngine implements Nethack3DEngineController {
     const fpsHeldWeaponSpriteFlipXChanged =
       previous.fpsHeldWeaponSpriteFlipX !== normalized.fpsHeldWeaponSpriteFlipX;
     const tilesetModeChanged = previous.tilesetMode !== normalized.tilesetMode;
+    const asciiColorModeChanged =
+      previous.asciiColorMode !== normalized.asciiColorMode;
     const tilesetPathChanged = previous.tilesetPath !== normalized.tilesetPath;
     const antialiasingChanged =
       previous.antialiasing !== normalized.antialiasing;
@@ -7158,6 +7161,10 @@ class Nethack3DEngine implements Nethack3DEngineController {
     }
     if (tilesetModeChanged) {
       this.clearMenuTilePreviewCache();
+      this.refreshTilesFromStateCache();
+    }
+    if (asciiColorModeChanged && !tilesetModeChanged) {
+      this.invalidateTilesetDependentCaches();
       this.refreshTilesFromStateCache();
     }
     if (fpsFlattenEntityBillboardsChanged && !tilesetModeChanged) {
@@ -16576,6 +16583,10 @@ class Nethack3DEngine implements Nethack3DEngineController {
       typeof mesh.userData?.glyphTextColor === "string"
         ? mesh.userData.glyphTextColor
         : "#F4F4F4";
+    const glyphBackgroundColor =
+      typeof mesh.userData?.glyphBackgroundColor === "string"
+        ? mesh.userData.glyphBackgroundColor
+        : null;
     const darkenFactor =
       typeof mesh.userData?.glyphDarkenFactor === "number"
         ? mesh.userData.glyphDarkenFactor
@@ -16611,6 +16622,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
       inferredDarkWallSolidColorHex,
       inferredDarkWallSolidColorGridEnabled,
       inferredDarkWallSolidColorGridDarknessPercent,
+      glyphBackgroundColor,
     );
   }
 
@@ -17898,6 +17910,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
     darkenFactor: number = 1,
     size: number = 256,
     drawFloorGrid: boolean = false,
+    backgroundColorHex: string | null = null,
   ): THREE.CanvasTexture {
     const canvas = document.createElement("canvas");
     canvas.width = size;
@@ -17914,6 +17927,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
       textColor,
       darkenFactor,
       drawFloorGrid,
+      backgroundColorHex,
     );
 
     const texture = new THREE.CanvasTexture(canvas);
@@ -17934,18 +17948,23 @@ class Nethack3DEngine implements Nethack3DEngineController {
     textColor: string,
     darkenFactor: number = 1,
     drawFloorGrid: boolean = false,
+    backgroundColorHex: string | null = null,
   ): void {
     context.clearRect(0, 0, size, size);
 
-    const tonedBackground = this.toneColor(
-      baseColorHex,
-      0.8 * THREE.MathUtils.clamp(darkenFactor, 0, 1),
-    );
-    const contrastBackground = this.ensureTextContrast(
-      tonedBackground,
-      textColor,
-    );
-    context.fillStyle = `#${contrastBackground}`;
+    if (backgroundColorHex && backgroundColorHex.length > 0) {
+      context.fillStyle = backgroundColorHex;
+    } else {
+      const tonedBackground = this.toneColor(
+        baseColorHex,
+        0.8 * THREE.MathUtils.clamp(darkenFactor, 0, 1),
+      );
+      const contrastBackground = this.ensureTextContrast(
+        tonedBackground,
+        textColor,
+      );
+      context.fillStyle = `#${contrastBackground}`;
+    }
     context.fillRect(0, 0, size, size);
 
     if (drawFloorGrid) {
@@ -20000,6 +20019,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
     solidColorHex: string | null = null,
     solidColorGridEnabled: boolean = false,
     solidColorGridDarknessPercent: number = 15,
+    glyphBackgroundColorHex: string | null = null,
   ): void {
     const overlay = this.ensureGlyphOverlay(key, baseMaterial);
     const baseColorHex = baseMaterial.color.getHexString();
@@ -20101,6 +20121,11 @@ class Nethack3DEngine implements Nethack3DEngineController {
             solidColorGridDarknessPercent,
           )
         : null;
+    const resolvedGlyphBackgroundColorHex =
+      typeof glyphBackgroundColorHex === "string" &&
+      glyphBackgroundColorHex.length > 0
+        ? glyphBackgroundColorHex
+        : null;
 
     let textureKey: string;
     if (useSolidColor) {
@@ -20110,7 +20135,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
         ? `vtile:${resolvedVultureLookupKey}|mk:${tileTextureMaterialKindKey}|${clampedDarken.toFixed(3)}`
         : `tile:${tileIndex}|sg:${tileTextureSourceGlyphKey}|mk:${tileTextureMaterialKindKey}|${tileUseBackgroundReferenceTileKey}|${tileTextureForceBackgroundRemovalKey}|ug:${floorUnderlayGlyphKey}|ui:${floorUnderlayTileIndexKey}|${floorUnderlayUseBackgroundReferenceTileKey}|umk:${floorUnderlayMaterialKindKey}|${clampedDarken.toFixed(3)}`;
     } else {
-      textureKey = `${baseColorHex}|${glyphChar}|${textColor}|${clampedDarken.toFixed(3)}|${drawFloorGrid ? 1 : 0}`;
+      textureKey = `${baseColorHex}|${glyphChar}|${textColor}|${clampedDarken.toFixed(3)}|${drawFloorGrid ? 1 : 0}|bg:${resolvedGlyphBackgroundColorHex ?? "none"}`;
     }
 
     if (overlay.textureKey !== textureKey) {
@@ -20156,6 +20181,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
             clampedDarken,
             256,
             drawFloorGrid,
+            resolvedGlyphBackgroundColorHex,
           ),
         );
       }
@@ -23134,6 +23160,10 @@ class Nethack3DEngine implements Nethack3DEngineController {
       typeof mesh.userData?.glyphTextColor === "string"
         ? mesh.userData.glyphTextColor
         : "#F4F4F4";
+    const glyphBackgroundColor =
+      typeof mesh.userData?.glyphBackgroundColor === "string"
+        ? mesh.userData.glyphBackgroundColor
+        : null;
     const darkenFactor =
       typeof mesh.userData?.glyphDarkenFactor === "number"
         ? mesh.userData.glyphDarkenFactor
@@ -23169,6 +23199,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
       inferredDarkWallSolidColorHex,
       inferredDarkWallSolidColorGridEnabled,
       inferredDarkWallSolidColorGridDarknessPercent,
+      glyphBackgroundColor,
     );
   }
 
@@ -26073,6 +26104,21 @@ class Nethack3DEngine implements Nethack3DEngineController {
       }
       tileTextColor = this.asciiFriendlyGlyphTextColor;
     }
+    let glyphBackgroundColorHex: string | null = null;
+    if (!useTiles && this.clientOptions.asciiColorMode === "classic") {
+      const netHackColorHex = getNetHackColorHex(behavior.resolved.color);
+      if (netHackColorHex) {
+        tileTextColor = netHackColorHex;
+      }
+      glyphBackgroundColorHex = "#1f1f1f";
+      const shouldUsePetReverseVideo =
+        renderBehavior.effective.kind === "pet" ||
+        renderBehavior.effective.kind === "ridden";
+      if (shouldUsePetReverseVideo && tileGlyphChar.trim().length > 0) {
+        glyphBackgroundColorHex = "#f2f2f2";
+        tileTextColor = "#0d0d0d";
+      }
+    }
     if (shouldTraceAsciiPlayerTile) {
       this.logAsciiPlayerTileDebug("update_tile_color_resolution", x, y, {
         hasSeenPlayerPosition: this.hasSeenPlayerPosition,
@@ -26178,6 +26224,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
     mesh.userData.tileTextureForceBackgroundRemoval =
       shouldForceTileTextureBackgroundRemoval;
     mesh.userData.glyphTextColor = tileTextColor;
+    mesh.userData.glyphBackgroundColor = glyphBackgroundColorHex;
     mesh.userData.glyphDarkenFactor = behavior.darkenFactor;
     mesh.userData.glyphBaseColorHex = material.color.getHexString();
     const tileTextureIndex =
@@ -26277,6 +26324,7 @@ class Nethack3DEngine implements Nethack3DEngineController {
       inferredDarkWallSolidColorHex,
       inferredDarkWallSolidColorGridEnabled,
       inferredDarkWallSolidColorGridDarknessPercent,
+      glyphBackgroundColorHex,
     );
     const hasFpsClosedDoorChamferTrim =
       this.isFpsMode() &&

--- a/src/game/glyphs/colors.ts
+++ b/src/game/glyphs/colors.ts
@@ -1,0 +1,46 @@
+const NETHACK_NO_COLOR_INDEX = 8;
+
+const NETHACK_COLOR_HEX_BY_INDEX: Readonly<Record<number, string>> = {
+  0: "#000000",
+  1: "#c62828",
+  2: "#2e7d32",
+  3: "#9c3d30",
+  4: "#1565c0",
+  5: "#8e24aa",
+  6: "#00838f",
+  7: "#9e9e9e",
+  9: "#ef6c00",
+  10: "#66bb6a",
+  11: "#fdd835",
+  12: "#42a5f5",
+  13: "#ec407a",
+  14: "#26c6da",
+  15: "#ffffff",
+};
+
+export function normalizeNetHackColorIndex(
+  color: number | null | undefined,
+): number | null {
+  if (typeof color !== "number" || !Number.isFinite(color)) {
+    return null;
+  }
+  return Math.trunc(color);
+}
+
+export function isNetHackNoColorIndex(
+  color: number | null | undefined,
+): boolean {
+  const normalized = normalizeNetHackColorIndex(color);
+  return normalized === NETHACK_NO_COLOR_INDEX;
+}
+
+export function getNetHackColorHex(
+  color: number | null | undefined,
+): string | null {
+  const normalized = normalizeNetHackColorIndex(color);
+  if (normalized === null || normalized === NETHACK_NO_COLOR_INDEX) {
+    return null;
+  }
+  const value = NETHACK_COLOR_HEX_BY_INDEX[normalized];
+  return typeof value === "string" ? value : null;
+}

--- a/src/game/ui-types.ts
+++ b/src/game/ui-types.ts
@@ -137,6 +137,7 @@ export type FpsCrosshairContextState = {
 
 export type PlayMode = "normal" | "fps";
 export type Nh3dAntialiasingMode = "taa" | "fxaa";
+export type Nh3dAsciiColorMode = "nethack-3d" | "classic";
 export type Nh3dDesktopTouchInterfaceMode = "off" | "portrait" | "landscape";
 export type Nh3dBloodDetailMode = "veryLow" | "low" | "medium" | "high";
 export type Nh3dInventoryFixedTileSizeMode =
@@ -251,6 +252,7 @@ export type Nh3dClientOptions = {
   fpsHeldWeaponSpriteFlipX: boolean;
   fpsHeldWeaponSpriteFlipXByTileset: TilesetWeaponSpriteFlipXByTileset;
   tilesetMode: "ascii" | "tiles";
+  asciiColorMode: Nh3dAsciiColorMode;
   tilesetPath: string;
   antialiasing: Nh3dAntialiasingMode;
   brightness: number;
@@ -411,6 +413,7 @@ export const defaultNh3dClientOptions: Nh3dClientOptions = {
     resolveDefaultNh3dTilesetWeaponSpriteFlipX(defaultNh3dTilesetPath),
   fpsHeldWeaponSpriteFlipXByTileset: {},
   tilesetMode: "tiles",
+  asciiColorMode: "nethack-3d",
   tilesetPath: defaultNh3dTilesetPath,
   antialiasing: "taa",
   brightness: 0,
@@ -1184,6 +1187,8 @@ export function normalizeNh3dClientOptions(
     fpsHeldWeaponSpriteFlipX,
     fpsHeldWeaponSpriteFlipXByTileset,
     tilesetMode,
+    asciiColorMode:
+      overrides?.asciiColorMode === "classic" ? "classic" : "nethack-3d",
     tilesetPath,
     antialiasing,
     brightness,

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -698,6 +698,15 @@ export const en = {
             tiles: "Tiles",
           },
         },
+        asciiColorMode: {
+          label: "ASCII Colors",
+          description:
+            "Color scheme used when rendering ASCII glyphs. Classic applies native NetHack colors with a dark background and reverse-video pet highlighting. NetHack 3D uses the original unmodified rendering.",
+          options: {
+            nethack3d: "NetHack 3D",
+            classic: "Classic",
+          },
+        },
         tilesetPath: {
           label: "Tileset",
           description: "Built-in and uploaded tilesets.",

--- a/src/i18n/locales/fi.ts
+++ b/src/i18n/locales/fi.ts
@@ -718,6 +718,15 @@ export const fiOverrides: LocaleOverrides<TranslationDictionary> = {
             tiles: "Ruudut",
           },
         },
+        asciiColorMode: {
+          label: "ASCII-värit",
+          description:
+            "ASCII-glyfien värimaailma. Klassinen käyttää alkuperäisiä NetHack-värejä tummalla taustalla ja lemmikeille käänteistä korostusta. NetHack 3D käyttää alkuperäistä muokkaamatonta renderöintiä.",
+          options: {
+            nethack3d: "NetHack 3D",
+            classic: "Klassinen",
+          },
+        },
         tilesetPath: {
           label: "Ruutusetti",
           description: "Sisäänrakennetut ja ladatut ruutusetit.",

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -726,6 +726,15 @@ export const fr = {
             tiles: "Tuiles",
           },
         },
+        asciiColorMode: {
+          label: "Couleurs ASCII",
+          description:
+            "Schéma de couleurs utilisé pour le rendu des glyphes ASCII. Classique applique les couleurs natives de NetHack avec un fond sombre et une mise en évidence inversée des familiers. NetHack 3D utilise le rendu d'origine non modifié.",
+          options: {
+            nethack3d: "NetHack 3D",
+            classic: "Classique",
+          },
+        },
         tilesetPath: {
           label: "Jeu de tuiles",
           description: "Jeux de tuiles integres et importes.",

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -673,6 +673,15 @@ export const jaOverrides: LocaleOverrides<TranslationDictionary> = {
             tiles: "タイル",
           },
         },
+        asciiColorMode: {
+          label: "ASCII カラー",
+          description:
+            "ASCII グリフ描画時の配色です。クラシックは暗い背景に NetHack 本来の色を使い、ペットを反転表示で強調します。NetHack 3D は元の未変更レンダリングを使用します。",
+          options: {
+            nethack3d: "NetHack 3D",
+            classic: "クラシック",
+          },
+        },
         tilesetPath: {
           label: "タイルセット",
           description: "組み込みタイルセットとアップロード済みタイルセットです。",

--- a/src/i18n/locales/ko.ts
+++ b/src/i18n/locales/ko.ts
@@ -698,6 +698,15 @@ export const ko = {
             tiles: "타일",
           },
         },
+        asciiColorMode: {
+          label: "ASCII 색상",
+          description:
+            "ASCII 글리프를 렌더링할 때 사용할 색상 구성입니다. 클래식은 어두운 배경에서 NetHack 원래 색상을 사용하고, 반전 표시로 펫을 강조합니다. NetHack 3D는 원래의 수정되지 않은 렌더링을 사용합니다.",
+          options: {
+            nethack3d: "NetHack 3D",
+            classic: "클래식",
+          },
+        },
         tilesetPath: {
           label: "타일셋",
           description: "내장 및 업로드한 타일셋입니다.",

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -697,6 +697,17 @@ export const ru = {
             tiles: "Тайлы",
           },
         },
+        asciiColorMode: {
+          label: "Цвета ASCII",
+          description:
+            "Цветовая схема для отображения ASCII-глифов. " +
+            "Классический режим использует родные цвета NetHack с тёмным фоном и обратной подсветкой питомцев. " +
+            "NetHack 3D использует исходный неизменённый рендеринг.",
+          options: {
+            nethack3d: "NetHack 3D",
+            classic: "Классический",
+          },
+        },
         tilesetPath: {
           label: "Тайлсет",
           description: "Встроенные и загруженные тайлсеты.",

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -2876,6 +2876,7 @@ type ClientOptionSelect = {
   key:
     | "locale"
     | "tilesetMode"
+    | "asciiColorMode"
     | "tilesetPath"
     | "antialiasing"
     | "inventoryFixedTileSize"
@@ -4439,6 +4440,22 @@ const clientOptionsConfig: ClientOption[] = [
       {
         value: "tiles",
         label: t.clientOptions.config.tilesetMode.options.tiles,
+      },
+    ],
+  },
+  {
+    key: "asciiColorMode",
+    label: t.clientOptions.config.asciiColorMode.label,
+    description: t.clientOptions.config.asciiColorMode.description,
+    type: "select",
+    options: [
+      {
+        value: "nethack-3d",
+        label: t.clientOptions.config.asciiColorMode.options.nethack3d,
+      },
+      {
+        value: "classic",
+        label: t.clientOptions.config.asciiColorMode.options.classic,
       },
     ],
   },
@@ -16590,6 +16607,15 @@ export default function App(): JSX.Element {
                                     ? event.target.value
                                     : "medium";
                                 updateClientOptionDraft(option.key, nextValue);
+                                return;
+                              }
+                              if (option.key === "asciiColorMode") {
+                                updateClientOptionDraft(
+                                  option.key,
+                                  event.target.value === "classic"
+                                    ? "classic"
+                                    : "nethack-3d",
+                                );
                                 return;
                               }
                               updateClientOptionDraft(


### PR DESCRIPTION
## Summary
- Add a new client option for ASCII color mode with NetHack 3D and Classic choices.
- Implement classic NetHack-style ASCII color mapping in the engine for ASCII rendering.
- Add UI wiring and translations for the new option.
- Remove unused outline-only glyph rendering path introduced during development to keep logic clear.

## Validation
- npm run check:tsc passes.

## Files
- src/game/Nethack3DEngine.ts
- src/game/glyphs/colors.ts
- src/game/ui-types.ts
- src/ui/App.tsx
- src/i18n/locales/en.ts
- src/i18n/locales/fi.ts
- src/i18n/locales/fr.ts
- src/i18n/locales/ja.ts
- src/i18n/locales/ko.ts
- src/i18n/locales/ru.ts
